### PR TITLE
connect/listen: add hex support for keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Options include:
 
 #### `const client = noise.connect(serverPublicKey, [keyPair])`
 
-Connect to a server. Does UDP hole punching if nessesary.
+Connect to a server. Does UDP hole punching if necessary.
+`serverPublicKey` must be of type Buffer or hex.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -79,6 +79,14 @@ class NoiseServer extends EventEmitter {
   listen (keyPair, cb) {
     if (!cb) cb = noop
 
+    if (!Buffer.isBuffer(keyPair.publicKey)) {
+      keyPair.publicKey = Buffer.from(keyPair.publicKey, 'hex')
+    }
+
+    if (!Buffer.isBuffer(keyPair.secretKey)) {
+      keyPair.secretKey = Buffer.from(keyPair.secretKey, 'hex')
+    }
+
     const self = this
 
     this.server.open(function (err) {
@@ -203,6 +211,8 @@ class NoiseAgent extends Nanoresource {
   connect (publicKey, keyPair) {
     this.open()
     this.active()
+
+    if (!Buffer.isBuffer(publicKey)) publicKey = Buffer.from(publicKey, 'hex')
 
     const rawStream = new RawStream(this, publicKey)
 

--- a/tests.js
+++ b/tests.js
@@ -20,3 +20,33 @@ test('destroy', function (assert) {
     client.end(assert.pass)
   })
 })
+
+test('accepts keys as hex', { timeout: 1000 }, function (assert) {
+  assert.plan(3)
+  var server = network.createServer()
+  var client
+
+  server.on('connection', function (encryptedStream) {
+    assert.pass('Connected')
+    encryptedStream.pipe(encryptedStream)
+    encryptedStream.on('error', assert.error)
+
+    encryptedStream.on('data', function (data) {
+      assert.pass('received data')
+
+      server.close()
+      client.end(assert.pass)
+    })
+  })
+
+  var serverKeys = network.keygen()
+  var keys = {
+    publicKey: serverKeys.publicKey.toString('hex'),
+    secretKey: serverKeys.secretKey.toString('hex')
+  }
+
+  server.listen(keys, function connectClient () {
+    client = network.connect(keys.publicKey)
+    client.write('hello')
+  })
+})


### PR DESCRIPTION
a common scenario when writing servers is that the keys are hex
encoded. before the fix, connection was failing silently.